### PR TITLE
RT and XRay latest versions to work with old prometheus

### DIFF
--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -57,7 +57,6 @@ additionalResources: |
     selector:
       app: {{ template "artifactory-ha.name" . }}
       component: "{{ .Values.artifactory.name }}"
-      release: {{ .Release.Name }}
   ---
   apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -9,7 +9,7 @@ artifactory:
         - '-c'
         - >
           mkdir -p {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/;
-          wget https://raw.githubusercontent.com/jfrog/log-analytics-prometheus/master/fluent.conf.rt -O {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          curl https://raw.githubusercontent.com/jfrog/log-analytics-prometheus/master/fluent.conf.rt -o {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
           name: artifactory-volume
@@ -57,7 +57,6 @@ additionalResources: |
     selector:
       app: {{ template "artifactory.name" . }}
       component: "{{ .Values.artifactory.name }}"
-      release: {{ .Release.Name }}
   ---
   apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -22,7 +22,7 @@ common:
         - '-c'
         - >
           mkdir -p {{ .Values.xray.persistence.mountPath }}/etc/fluentd/;
-          wget https://raw.githubusercontent.com/jfrog/log-analytics-prometheus/master/fluent.conf.xray -O {{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          curl https://raw.githubusercontent.com/jfrog/log-analytics-prometheus/master/fluent.conf.xray -o {{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"
           name: data-volume
@@ -69,7 +69,6 @@ additionalResources: |
     selector:
       app: {{ template "xray.name" . }}
       component: "{{ .Values.xray.name }}"
-      release: {{ .Release.Name }}
   ---
   apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor


### PR DESCRIPTION
RT and XRay latest versions to work with old prometheus

Selector is wrong in case the Deployment of Prometheus is done earlier and then RT or Xray is deployed.

WGET command is changed to CURL, as the image does not support WGET