### PR TITLE
PTRENG-6034 - partnership registry deprecation + helm charts updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.8] - June 7, 2024
+
+* [BREAKING] Adding deprecation notice for partnership-pts-observability.jfrog.io docker registry
+* FluentD sidecar version bumped to 4.3, to upgrade base image to bitnami/fluentd 1.16.5
+* Update helm charts for FluentD sidecar to match recent init containers charts changes in JFrog's official charts
+
 ## [1.0.7] - May 8, 2024
 
 * Fix issue where loki helm values file not compatible with loki 3.x

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ This guide assumes the implementer is performing new setup, Changes to handle in
 
 If Prometheus and Loki are already available you can skip the installation section and proceed to [Configuration Section](#Configuration).
 
+> [!WARNING]
+>
+> The old docker registry `partnership-pts-observability.jfrog.io`, which contains older versions of this integration is now deprecated. We'll keep the existing docker images on this old registry until August 1st, 2024. After that date, this registry will no longer be available. Please `helm upgrade` your JFrog kubernetes deployment in order to pull images as specified on the above helm value files, from the new `releases-pts-observability-fluentd.jfrog.io` registry. Please do so in order to avoid `ImagePullBackOff` errors in your deployment once this registry is gone.
+
 # Installation
 
 ## Installing Prometheus, Loki and Grafana on Kubernetes

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -10,7 +10,7 @@ artifactory:
     enabled: true
   customInitContainersBegin: |
     - name: "prepare-fluentd-conf-on-persistent-volume"
-      image: "{{ .Values.initContainerImage }}"
+      image: {{ include "artifactory.getImageInfoByValue" (list . "initContainers") }}
       imagePullPolicy: "{{ .Values.artifactory.image.pullPolicy }}"
       command:
         - 'sh'
@@ -23,7 +23,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.2"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -10,7 +10,7 @@ artifactory:
     enabled: true
   customInitContainersBegin: |
     - name: "prepare-fluentd-conf-on-persistent-volume"
-      image: "{{ .Values.initContainerImage }}"
+      image: {{ include "artifactory.getImageInfoByValue" (list . "initContainers") }}
       imagePullPolicy: "{{ .Values.artifactory.image.pullPolicy }}"
       command:
         - 'sh'
@@ -23,7 +23,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.2"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/jfrog-platform-values.yaml
+++ b/helm/jfrog-platform-values.yaml
@@ -12,7 +12,7 @@ artifactory:
     replicaCount: 1
     customInitContainersBegin: |
       - name: "prepare-fluentd-conf-on-persistent-volume"
-        image: "{{ .Values.initContainerImage }}"
+        image: {{ include "artifactory.getImageInfoByValue" (list . "initContainers") }}
         imagePullPolicy: "{{ .Values.artifactory.image.pullPolicy }}"
         command:
           - 'sh'
@@ -25,7 +25,7 @@ artifactory:
             name: artifactory-volume
     customSidecarContainers: |
       - name: "artifactory-fluentd-sidecar"
-        image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.2"
+        image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -26,7 +26,7 @@ common:
   preStartCommand: "export JF_OBSERVABILITY_METRICS_ENABLED=true"
   customInitContainersBegin: |
     - name: "download-fluentd-conf-on-persistent-volume"
-      image: "{{ .Values.initContainerImage }}"
+      image: {{ include "xray.getImageInfoByValue" (list . "initContainers") }}
       imagePullPolicy: "{{ .Values.imagePullPolicy }}"
       command:
         - 'sh'
@@ -39,7 +39,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.2"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
- init container helm chart changes to match JFrog's official helm charts changes
- Deprecation note for partership docker registry
- upgrade sidecar to use bitnami/fluentd:1.16.5 as a base image