### PR TITLE
JOBS-924 - Download fluentd image from releases-docker.jfrog.io domain instead of partnership-pts-observability.jfrog.io. It is now deprecated

### DIFF
--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -24,7 +24,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.15"
+      image: "releases-docker.jfrog.io/fluentd:4.15"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/jfrog-platform-values.yaml
+++ b/helm/jfrog-platform-values.yaml
@@ -25,7 +25,7 @@ artifactory:
             name: artifactory-volume
     customSidecarContainers: |
       - name: "artifactory-fluentd-sidecar"
-        image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.15"
+        image: "releases-docker.jfrog.io/fluentd:4.15"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -53,7 +53,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.15"
+      image: "releases-docker.jfrog.io/fluentd:4.15"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
Download fluentd image from releases-docker.jfrog.io domain instead of partnership-pts-observability.jfrog.io. It is now deprecated.