### PR TITLE
JOBS-2092: Add RTFS metrics support in log-analytics-prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.2.0] - April 2026
+
+* Added RTFS (Real-Time File Store) metrics collection support via tail source and Prometheus filter (JOBS-1897)
+* RTFS metrics are exposed as Prometheus gauge metrics with `service: rtfs` label
+
 ## [1.1.0] - August 2025
 
 * Upgrade application versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes to the log analytics integration will be documented in this file.
 
 ## [1.2.0] - April 2026
 
-* Added RTFS (Real-Time File Store) metrics collection support via tail source and Prometheus filter (JOBS-1897)
+* Added RTFS (JFrog Artifactory Federation Service) metrics collection support via tail source and Prometheus filter (JOBS-1897)
 * RTFS metrics are exposed as Prometheus gauge metrics with `service: rtfs` label
 
 ## [1.1.0] - August 2025

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ helm upgrade --install artifactory jfrog/artifactory \
 
 :bulb: Open Metrics is disabled by default in Artifactory. It's enabled by setting `artifactory.metrics.enabled=true`.
 
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), RTFS metrics are automatically collected from the `rtfs-metrics.log` file and exposed as Prometheus gauge metrics. The fluentd config already includes an RTFS metrics tail source and corresponding Prometheus filter that runs alongside the standard Artifactory metrics collection. RTFS metrics are labeled with `service: rtfs` to distinguish them from standard Artifactory metrics.
+
 3. Follow the instructions how to get your new Artifactory URL from the helm install output
 
 ```shell
@@ -260,6 +262,8 @@ Example dashboards are included in the [grafana](grafana) directory. These dashb
 
 - Artifactory Application Metrics (Open Metrics) Dashboard [Download Here](grafana/ArtifactoryMetrics.json)
 - Xray Application Metrics (Open Metrics) Dashboard [Download Here](grafana/XrayMetrics.json)
+
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from the `rtfs-metrics.log` file and exposed as Prometheus gauge metrics with the `service: rtfs` label. These metrics can be visualized in Grafana alongside standard Artifactory metrics.
 
 1. After downloading the dashboards go to "Dashboards" -> "New" -> "Import"
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ helm upgrade --install artifactory jfrog/artifactory \
 
 :bulb: Open Metrics is disabled by default in Artifactory. It's enabled by setting `artifactory.metrics.enabled=true`.
 
-:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), RTFS metrics are automatically collected from the `rtfs-metrics.log` file and exposed as Prometheus gauge metrics. The fluentd config already includes an RTFS metrics tail source and corresponding Prometheus filter that runs alongside the standard Artifactory metrics collection. RTFS metrics are labeled with `service: rtfs` to distinguish them from standard Artifactory metrics.
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (JFrog Artifactory Federation Service), RTFS metrics are automatically collected from the `rtfs-metrics.log` file and exposed as Prometheus gauge metrics. The fluentd config already includes an RTFS metrics tail source and corresponding Prometheus filter that runs alongside the standard Artifactory metrics collection. RTFS metrics are labeled with `service: rtfs` to distinguish them from standard Artifactory metrics.
 
 3. Follow the instructions how to get your new Artifactory URL from the helm install output
 

--- a/fluent_metrics.conf.rt
+++ b/fluent_metrics.conf.rt
@@ -33,6 +33,180 @@
     @type none
   </parse>
 </source>
+<source>
+  @type tail
+  @id rtfs_metrics_tail
+  path "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/log/rtfs-metrics.log"
+  pos_file "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/log/rtfs-metrics.log.pos"
+  tag jfrog.metrics.rtfs
+  read_from_head true
+  refresh_interval 10
+  follow_inodes true
+  skip_refresh_on_startup true
+  read_bytes_limit_per_second 104857600
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<filter jfrog.metrics.rtfs>
+  @type parser
+  key_name message
+  <parse>
+    @type regexp
+    expression ^(?<key>[\w]+)\ (?<value>[[+-]?\d(\.\d+)?[Ee][+-]?\d+]+)\ (?<timestamp>[\d]+)$
+    time_type string
+    time_key timestamp
+    time_format %s
+  </parse>
+  emit_invalid_record_to_error false
+</filter>
+
+<filter jfrog.metrics.rtfs>
+  @type record_transformer
+  enable_ruby true
+  renew_record false
+  <record>
+    ${record["key"]} ${if record["value"]["."] then record["value"].to_f else record["value"].to_i end}
+  </record>
+</filter>
+
+<filter jfrog.metrics.rtfs>
+  @type prometheus
+
+  <metric>
+    name jfrt_rtfs_runtime_heap_freememory_bytes
+    desc RTFS Heap Free Memory in Bytes
+    type gauge
+    key jfrt_rtfs_runtime_heap_freememory_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name jfrt_rtfs_runtime_heap_maxmemory_bytes
+    desc RTFS Heap Max Memory in Bytes
+    type gauge
+    key jfrt_rtfs_runtime_heap_maxmemory_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name jfrt_rtfs_runtime_heap_totalmemory_bytes
+    desc RTFS Heap Total Memory in Bytes
+    type gauge
+    key jfrt_rtfs_runtime_heap_totalmemory_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name jfrt_rtfs_db_connections_active_total
+    desc RTFS Active DB Connections
+    type gauge
+    key jfrt_rtfs_db_connections_active_total
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name jfrt_rtfs_db_connections_idle_total
+    desc RTFS Idle DB Connections
+    type gauge
+    key jfrt_rtfs_db_connections_idle_total
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name jfrt_rtfs_storage_current_total_size_bytes
+    desc RTFS Storage in Bytes
+    type gauge
+    key jfrt_rtfs_storage_current_total_size_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name app_rtfs_disk_used_bytes
+    desc RTFS Application Disk Used in Bytes
+    type gauge
+    key app_rtfs_disk_used_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name app_rtfs_disk_free_bytes
+    desc RTFS Application Disk Free in Bytes
+    type gauge
+    key app_rtfs_disk_free_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name sys_rtfs_memory_used_bytes
+    desc RTFS System Memory Used in Bytes
+    type gauge
+    key sys_rtfs_memory_used_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name sys_rtfs_memory_free_bytes
+    desc RTFS System Memory Free in Bytes
+    type gauge
+    key sys_rtfs_memory_free_bytes
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+  <metric>
+    name sys_rtfs_cpu_ratio
+    desc RTFS System CPU Ratio
+    type gauge
+    key sys_rtfs_cpu_ratio
+    <labels>
+      agent fluentd
+      host ${hostname}
+      service rtfs
+    </labels>
+  </metric>
+
+</filter>
 
 <filter jfrog.metrics.rt>
   @type parser


### PR DESCRIPTION
Add RTFS (Real-Time File Store) metrics collection support via a tail source and Prometheus filter in the Artifactory fluentd metrics config. RTFS metrics are read from rtfs-metrics.log and exposed as Prometheus gauge metrics with the service:rtfs label.

Changes:
- Add RTFS metrics tail source in fluent_metrics.conf.rt
- Add Prometheus filter with RTFS-specific gauge metrics
- Update README with RTFS metrics documentation
- Update CHANGELOG with new version entry

Parent ticket: JOBS-1897

Testing Done:
**Container**: `jfrog-fluentd-prometheus-rt`
**Test method**: Injected RTFS metrics into `rtfs-metrics.log` (simulating Artifactory), then scraped Fluentd's Prometheus endpoint.
**Command**:
```bash
curl http://localhost:24231/metrics | grep rtfs
```
**Result -- all 11 RTFS gauges exposed with `service="rtfs"` label**:
```
jfrt_rtfs_runtime_heap_freememory_bytes{agent="fluentd",host="...",service="rtfs"} 536870900.0
jfrt_rtfs_runtime_heap_maxmemory_bytes{agent="fluentd",host="...",service="rtfs"} 1073741824.0
jfrt_rtfs_runtime_heap_totalmemory_bytes{agent="fluentd",host="...",service="rtfs"} 838860800.0
jfrt_rtfs_db_connections_active_total{agent="fluentd",host="...",service="rtfs"} 3.0
jfrt_rtfs_db_connections_idle_total{agent="fluentd",host="...",service="rtfs"} 7.0
jfrt_rtfs_storage_current_total_size_bytes{agent="fluentd",host="...",service="rtfs"} 536870912.0
app_rtfs_disk_used_bytes{agent="fluentd",host="...",service="rtfs"} 10737418240.0
app_rtfs_disk_free_bytes{agent="fluentd",host="...",service="rtfs"} 96636764160.0
sys_rtfs_memory_used_bytes{agent="fluentd",host="...",service="rtfs"} 4294967296.0
sys_rtfs_memory_free_bytes{agent="fluentd",host="...",service="rtfs"} 12884901888.0
sys_rtfs_cpu_ratio{agent="fluentd",host="...",service="rtfs"} 0.25
```
UI: The Prometheus /metrics endpoint is the raw scrape target - in a real deployment, Prometheus scrapes this and Grafana visualizes it.
<img width="1725" height="717" alt="Screenshot 2026-04-22 at 4 45 08 PM" src="https://github.com/user-attachments/assets/b5642635-5198-45e6-8d19-905bdc598af8" />
