### PR TITLE
JOBS-2126: Bump fluentd sidecar image from 4.15 to 4.19

### DIFF
--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -24,7 +24,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.15"
+      image: "releases-docker.jfrog.io/fluentd:4.19"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/jfrog-platform-values.yaml
+++ b/helm/jfrog-platform-values.yaml
@@ -25,7 +25,7 @@ artifactory:
             name: artifactory-volume
     customSidecarContainers: |
       - name: "artifactory-fluentd-sidecar"
-        image: "releases-docker.jfrog.io/fluentd:4.15"
+        image: "releases-docker.jfrog.io/fluentd:4.19"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -162,7 +162,7 @@ xray:
             name: data-volume
     customSidecarContainers: |
       - name: "xray-platform-fluentd-sidecar"
-        image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.5"
+        image: "releases-docker.jfrog.io/fluentd:4.19"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.xray.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -53,7 +53,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.15"
+      image: "releases-docker.jfrog.io/fluentd:4.19"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
**Summary**

- Update fluentd sidecar Docker image tag from `4.15` to `4.19` in all Helm values files
- Image `4.19` includes `fluent-plugin-jfrog-metrics` gem v0.2.17 with RTFS metrics support and timestamp fix for NewRelic/Splunk parsers