### PR TITLE
JOBS-2475: Bump fluentd sidecar image to 4.20 (Echo secure base)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.2.2] - June 2026
+
+* Fluentd sidecar image bumped to 4.20: migrated to Echo secure base (fluentd 1.19.2, Debian 13), remediating Critical/High CVEs in 4.19 (JOBS-2475)
+
 ## [1.2.1] - April 2026
 
 * Fix incorrect field name in access-security-audit log parsing: renamed `token_id` capture group to `trace_id` to match the actual log format documented at https://docs.jfrog.com/administration/docs/audit-trail-log (JOBS-2031)

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -24,7 +24,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/jfrog-platform-values.yaml
+++ b/helm/jfrog-platform-values.yaml
@@ -25,7 +25,7 @@ artifactory:
             name: artifactory-volume
     customSidecarContainers: |
       - name: "artifactory-fluentd-sidecar"
-        image: "releases-docker.jfrog.io/fluentd:4.19"
+        image: "releases-docker.jfrog.io/fluentd:4.20"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -162,7 +162,7 @@ xray:
             name: data-volume
     customSidecarContainers: |
       - name: "xray-platform-fluentd-sidecar"
-        image: "releases-docker.jfrog.io/fluentd:4.19"
+        image: "releases-docker.jfrog.io/fluentd:4.20"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.xray.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -53,7 +53,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
**Summary**

- Bumps Helm sidecar image tag from `4.19` to `4.20` across all values files (artifactory, xray, jfrog-platform)
- The new `fluentd:4.20` image is built on Echo secure base (`reg.echohq.com/fluentd:1.19.2`, Debian 13 Trixie)
- Remediates Critical/High CVEs in the `fluentd:4.19` image: CVE-2026-31789 (OpenSSL), CVE-2026-33845, CVE-2026-42010 (libgnutls30)

Tracked by: [JOBS-2475](https://jfrog-int.atlassian.net/browse/JOBS-2475), [INTG-825](https://jfrog-int.atlassian.net/browse/INTG-825)
Testing Done:
<img width="954" height="1460" alt="prom-app-disk-free-table" src="https://github.com/user-attachments/assets/ff6dbbdf-e5bd-40f1-a3a8-fa5a5212dbf7" />
<img width="954" height="1460" alt="prom-targets-up" src="https://github.com/user-attachments/assets/29b541e0-41bf-4386-b46c-2ac41fda202e" />
