### PR TITLE
JOBS-2475: Bump fluentd sidecar image to 4.21 (Helm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.2.2] - June 2026
+
+* Fluentd sidecar image bumped to 4.21 in the Helm values: now pulls the released image `releases-docker.jfrog.io/fluentd:4.21` directly (fluentd 1.19.2 on a hardened, CVE-refreshed base), remediating Critical/High CVEs in 4.19 (JOBS-2475)
+
 ## [1.2.1] - April 2026
 
 * Fix incorrect field name in access-security-audit log parsing: renamed `token_id` capture group to `trace_id` to match the actual log format documented at https://docs.jfrog.com/administration/docs/audit-trail-log (JOBS-2031)

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -24,7 +24,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/jfrog-platform-values.yaml
+++ b/helm/jfrog-platform-values.yaml
@@ -25,7 +25,7 @@ artifactory:
             name: artifactory-volume
     customSidecarContainers: |
       - name: "artifactory-fluentd-sidecar"
-        image: "releases-docker.jfrog.io/fluentd:4.19"
+        image: "releases-docker.jfrog.io/fluentd:4.21"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -162,7 +162,7 @@ xray:
             name: data-volume
     customSidecarContainers: |
       - name: "xray-platform-fluentd-sidecar"
-        image: "releases-docker.jfrog.io/fluentd:4.19"
+        image: "releases-docker.jfrog.io/fluentd:4.21"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.xray.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -53,7 +53,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
**Summary**
Bump the fluentd sidecar image to the already-promoted public image `releases-docker.jfrog.io/fluentd:4.21` (this repo ships Helm values only — no docker-build dir).

- **helm/*-values.yaml**: bump the fluentd sidecar image `4.19 -> 4.21` (artifactory, jfrog-platform [artifactory + xray sidecars], xray).
- **CHANGELOG**: add the 4.21 entry.

`releases-docker.jfrog.io/fluentd:4.21` is public (pullable with no auth) and is fluentd 1.19.2 on a hardened, CVE-refreshed base (remediates the Critical/High CVEs in 4.19).

Supersedes #75 (Echo/4.20 Helm) — it will be closed in favor of this PR.

**Testing Done (released image, live E2E)**
- Promoted image checked: uid 999, fluentd 1.19.2, curl present, all 12 plugins baked in, no gcc/cc/make.
- Ran the sidecar on the promoted image against a live Artifactory; the local Prometheus scrape target `jfrog-artifactory-fluentd-rel-421` reports **health=up** and `jfrt_*` gauges are scraped.
<img width="1724" height="801" alt="Screenshot 2026-06-24 at 12 25 24 PM" src="https://github.com/user-attachments/assets/125460cd-844a-450e-a56b-9ccc0a05ca06" />
