### PR TITLE
JOBS-2583 - Bump fluentd sidecar image to 4.22 (Echo 1.19.3, CVE-2026-55200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.2.3] - June 2026
+
+* Fluentd sidecar image bumped to 4.22 in the Helm values: now pulls the released image `releases-docker.jfrog.io/fluentd:4.22` directly (fluentd 1.19.3 on the refreshed hardened Echo base), remediating the critical OS-package vulnerability CVE-2026-55200 in libssh2 (1.11.1-1+e1 -> 1.11.1-1+e2) carried by the 4.21 base image (JOBS-2583)
+
 ## [1.2.2] - June 2026
 
 * Fluentd sidecar image bumped to 4.21 in the Helm values: now pulls the released image `releases-docker.jfrog.io/fluentd:4.21` directly (fluentd 1.19.2 on a hardened, CVE-refreshed base), remediating Critical/High CVEs in 4.19 (JOBS-2475)

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -24,7 +24,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.21"
+      image: "releases-docker.jfrog.io/fluentd:4.22"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/jfrog-platform-values.yaml
+++ b/helm/jfrog-platform-values.yaml
@@ -25,7 +25,7 @@ artifactory:
             name: artifactory-volume
     customSidecarContainers: |
       - name: "artifactory-fluentd-sidecar"
-        image: "releases-docker.jfrog.io/fluentd:4.21"
+        image: "releases-docker.jfrog.io/fluentd:4.22"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -162,7 +162,7 @@ xray:
             name: data-volume
     customSidecarContainers: |
       - name: "xray-platform-fluentd-sidecar"
-        image: "releases-docker.jfrog.io/fluentd:4.21"
+        image: "releases-docker.jfrog.io/fluentd:4.22"
         imagePullPolicy: "IfNotPresent"
         volumeMounts:
           - mountPath: "{{ .Values.xray.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -53,7 +53,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.21"
+      image: "releases-docker.jfrog.io/fluentd:4.22"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
## Summary
- Bump shared fluentd image `4.21` -> `4.22` in Helm values.
- fluentd 1.19.3 on Echo base `1.19.3-20260627`; remediates CVE-2026-55200 (libssh2).

## Test plan
- [x] entplus `fluentd:4.22` image validated
<img width="1938" height="781" alt="Screenshot 2026-06-30 at 5 11 14 PM" src="https://github.com/user-attachments/assets/174b6eaf-c578-410c-ae91-0f9f2b6df139" />
